### PR TITLE
Sedivy/#3 organ endpoint

### DIFF
--- a/src/models/sab_code_term.py
+++ b/src/models/sab_code_term.py
@@ -106,3 +106,10 @@ class SabCodeTerm(Model):
         """
 
         self._term = term
+
+    def serialize(self):
+        return {
+            "code": self._code,
+            "sab": self._sab,
+            "term": self._term
+        }

--- a/src/neo4j_manager.py
+++ b/src/neo4j_manager.py
@@ -591,7 +591,7 @@ class Neo4jManager(object):
             recds: neo4j.Result = session.run(query)
             for record in recds:
                 try:
-                    sabcodeterm: [SabCodeTerm] = SabCodeTerm(record.get('sab'), record.get('code'), record.get('term'))
+                    sabcodeterm: [SabCodeTerm] = SabCodeTerm(record.get('sab'), record.get('code'), record.get('term')).serialize()
                     sabcodeterms.append(sabcodeterm)
                 except KeyError:
                     pass

--- a/src/routes/datasets/datasets_controller.py
+++ b/src/routes/datasets/datasets_controller.py
@@ -32,4 +32,4 @@ def dataset_get(application_context='HUBMAP', data_type=None, description=None, 
     """
     return jsonify(
         current_app.neo4jManager.dataset_get(request.args.get('application_context'), data_type, description, alt_name, primary, contains_pii, vis_only,
-                                 vitessce_hint, dataset_provider))
+                                 vitessce_hint, request.args.get('dataset_provider')))

--- a/src/routes/datasets/datasets_controller.py
+++ b/src/routes/datasets/datasets_controller.py
@@ -4,8 +4,7 @@ datasets_blueprint = Blueprint('datasets', __name__, url_prefix='/datasets')
 
 
 @datasets_blueprint.route('', methods=['GET'])
-def dataset_get(application_context='HUBMAP', data_type=None, description=None, alt_name=None, primary=None, contains_pii=None,
-                vis_only=None, vitessce_hint=None, dataset_provider=None):
+def dataset_get():
     """Returns information on a set of HuBMAP or SenNet dataset types, with options to filter the list to those with specific property values. Filters are additive (i.e., boolean AND)
 
 
@@ -31,5 +30,9 @@ def dataset_get(application_context='HUBMAP', data_type=None, description=None, 
     :rtype: Union[List[DatasetPropertyInfo], Tuple[List[DatasetPropertyInfo], int], Tuple[List[DatasetPropertyInfo], int, Dict[str, str]]
     """
     return jsonify(
-        current_app.neo4jManager.dataset_get(request.args.get('application_context'), data_type, description, alt_name, primary, contains_pii, vis_only,
-                                 vitessce_hint, request.args.get('dataset_provider')))
+        current_app.neo4jManager.dataset_get(
+            request.args.get('application_context'), request.args.get('data_type'),
+            request.args.get('description'), request.args.get('alt_name'), request.args.get('primary'),
+            request.args.get('contains_pii'), request.args.get('vis_only'),
+            request.args.get('vitessce_hint'), request.args.get('dataset_provider'))
+    )

--- a/src/routes/valueset/valueset_controller.py
+++ b/src/routes/valueset/valueset_controller.py
@@ -1,10 +1,10 @@
-from flask import Blueprint, jsonify, current_app
+from flask import Blueprint, jsonify, current_app, request
 
 valueset_blueprint = Blueprint('valueset', __name__, url_prefix='/valueset')
 
 
-@valueset_blueprint.route('/', methods=['GET'])
-def valueset_get(parent_sab, parent_code, child_sabs):
+@valueset_blueprint.route('', methods=['GET'])
+def valueset_get():
     """Returns a valueset of concepts that are children (have as isa relationship) of another concept.
 
 
@@ -17,4 +17,7 @@ def valueset_get(parent_sab, parent_code, child_sabs):
 
     :rtype: Union[List[SabCodeTerm], Tuple[List[SabCodeTerm], int], Tuple[List[SabCodeTerm], int, Dict[str, str]]
     """
-    return jsonify(current_app.neo4jManager.valueset_get(parent_sab, parent_code, child_sabs))
+    child_sabs = request.args.getlist('child_sabs')
+    return jsonify(
+        current_app.neo4jManager.valueset_get(request.args.get('parent_sab'), request.args.get('parent_code'),
+                                              child_sabs))

--- a/ubkg-api-spec.yaml
+++ b/ubkg-api-spec.yaml
@@ -4,7 +4,10 @@ info:
   description: This document describes the UBKG API
   version: 1.2.0
 servers:
-  - url: https://ontology.src.hubmapconsortium.org/
+  - url: https://ontology.api.hubmapconsortium.org/
+    description: Production server
+  - url: https://ontology-api.dev.hubmapconsortium.org/
+    description: Development server
 paths:
   /codes/{code_id}/codes:
     get:


### PR DESCRIPTION
Address issues after testing in DEV

1. Fixed redirect and query string issues with the `/valueset` endpoint
2. Fixed query string issues with the `/datasets` endpoint
3. Updated the `ubkg-api-spec.yaml` to include Production and Development server URLs