### PR TITLE
Deprecate validation_application_context

### DIFF
--- a/src/ubkg_api/common_routes/deprecated/validate.py
+++ b/src/ubkg_api/common_routes/deprecated/validate.py
@@ -1,3 +1,7 @@
+# August 2024
+# The validate_application_context logic is specific to the HuBMAP/SenNet UBKG context. The functionality has been
+# moved to the code base in the hs-ontology-api repository.
+
 from flask import request, abort, jsonify
 
 

--- a/src/ubkg_api/cypher/sources.cypher
+++ b/src/ubkg_api/cypher/sources.cypher
@@ -16,7 +16,7 @@ CALL
 CALL
 {
 	WITH CUISource
-	 MATCH (pSource:Concept)-[:has_sab]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
+	MATCH (pSource:Concept)-[:has_sab]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
 	WHERE pSource.CUI=CUISource
 	$sabfilter
 	AND r.CUI = p.CUI
@@ -44,7 +44,7 @@ CALL
 CALL
 {
 	WITH CUISource
-	MATCH (pSource:Concept)-[:has_home_url]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
+	OPTIONAL MATCH (pSource:Concept)-[:has_home_url]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
 	WHERE pSource.CUI=CUISource
 	AND r.CUI = p.CUI
 	RETURN COLLECT(t.name) AS home_urls
@@ -53,7 +53,7 @@ CALL
 CALL
 {
 	WITH CUISource
-	MATCH (pSource:Concept)-[:has_source_dictionary_url]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
+	OPTIONAL MATCH (pSource:Concept)-[:has_source_dictionary_url]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
 	WHERE pSource.CUI=CUISource
 	AND r.CUI = p.CUI
 	RETURN t.name AS source_dictionary_url
@@ -62,7 +62,7 @@ CALL
 CALL
 {
 	WITH CUISource
-	MATCH (pSource:Concept)-[:has_citation]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
+	OPTIONAL MATCH (pSource:Concept)-[:has_citation]->(p:Concept)-[:CODE]->(c:Code)-[r:PT]->(t:Term)
 	WHERE pSource.CUI=CUISource
 	AND r.CUI = p.CUI
 	RETURN COLLECT(DISTINCT {PMID:split(t.name,':')[1], url:'https://pubmed.ncbi.nlm.nih.gov/'+split(t.name,':')[1]}) AS citations

--- a/ubkg-api-spec.yaml
+++ b/ubkg-api-spec.yaml
@@ -459,7 +459,7 @@ paths:
           description: A sequential set of relationships that specifies the pattern of relationships in the paths in the subgraph. Each element in the set should be in format SAB:relationship type. SAB corresponds to the source in which the relationship was asserted--e.g., "NCI:is_marked_by_gene_product" corresponds to the "is_marked_by_gene_product" relationship asserted in NCI. The set can be specified with a list of values delimited with commas (e.g., ?relsequence=SAB1:relationshiptype1,SAB2:relationshiptype2) or with individual key-value pairs (e.g., ?relsequence=SAB1:relationship_type1&relsequence=SAB2:relationshiptype2).
           schema:
             type: string
-            example: NCI:is_marked_by_gene_product,NCI:3Agene_product_encoded_by_gene
+            example: NCI:is_marked_by_gene_product,NCI:gene_product_encoded_by_gene
         - name: skip
           in: query
           required: false


### PR DESCRIPTION
This deprecates the remanining functionality that should have been moved to hs-ontology-api when it was created as part of the refactoring of ubkg-api.

Validation: 
hs-ontology-api calls ubkg-api as a library/package. 

This was tested with a development branch of hs-ontology-api that pointed to the following instance of ubkg-api:

git+https://github.com/x-atlas-consortia/ubkg-api.git@simmons/deprecate_validate_application_context

Test scripts ran as expected.

ADDITIONAL TASKS:
Once merged, 
1. Compile a new version of the ubkg-api PyPI package. 
2. Deploy to Data Distillery API.
