### PR TITLE
Added timeout and payload size checking to all endpoints

### DIFF
--- a/src/ubkg_api/common_routes/concepts/concepts_controller.py
+++ b/src/ubkg_api/common_routes/concepts/concepts_controller.py
@@ -42,8 +42,15 @@ def concepts_concept_id_codes_get(concept_id):
     if result is None or result == []:
         # Empty result
         err = get_404_error_string(prompt_string='No Codes with link to the specified Concept',
-                                   custom_request_path=f'concept_id = {concept_id}')
+                                   custom_request_path=f'concept_id = {concept_id}',
+                                   timeout=neo4j_instance.timeout)
         return make_response(err, 404)
+
+    # Feb 2025
+    # Limit the size of the payload, based on the app configuration.
+    err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
+    if err != "ok":
+        return make_response(err, 413)
 
     return jsonify(result)
 
@@ -64,8 +71,15 @@ def concepts_concept_id_concepts_get(concept_id):
     if result is None or result == []:
         # Empty result
         err = get_404_error_string(prompt_string='No Concepts with relationships to the specified Concept',
-                                   custom_request_path=f'concept_id = {concept_id}')
+                                   custom_request_path=f'concept_id = {concept_id}',
+                                   timeout=neo4j_instance.timeout)
         return make_response(err, 404)
+
+    # Feb 2025
+    # Limit the size of the payload, based on the app configuration.
+    #err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
+    #if err != "ok":
+       # return make_response(err, 413)
 
     return jsonify(result)
 
@@ -83,24 +97,17 @@ def concepts_concept_id_definitions_get(concept_id):
     if result is None or result == []:
         # Empty result
         err = get_404_error_string(prompt_string='No Definitions for specified Concept',
-                                   custom_request_path=f"concept_id='{concept_id}'")
+                                   custom_request_path=f"concept_id='{concept_id}'",
+                                   timeout=neo4j_instance.timeout)
         return make_response(err, 404)
 
+    # Feb 2025
+    # Limit the size of the payload, based on the app configuration.
+    err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
+    if err != "ok":
+        return make_response(err, 413)
+
     return jsonify(result)
-
-# JAS January 2024 deprecating semantics endpoints.
-# @concepts_blueprint.route('<concept_id>/semantics', methods=['GET'])
-# def concepts_concept_id_semantics_get(concept_id):
-#    """Returns a list of semantic_types {Sty, Tui, Stn} of the concept
-#
-#    :param concept_id: The concept identifier
-#    :type concept_id: str
-#
-#    :rtype: Union[List[StyTuiStn], Tuple[List[StyTuiStn], int], Tuple[List[StyTuiStn], int, Dict[str, str]]
-#    """
-#    neo4j_instance = current_app.neo4jConnectionHelper.instance()
-#    return jsonify(concepts_concept_id_semantics_get_logic(neo4j_instance, concept_id))
-
 
 # JAS January 2024 Converted from POST to GET.
 @concepts_blueprint.route('<concept_id>/paths/expand', methods=['GET'])
@@ -186,7 +193,7 @@ def concepts_paths_expand_get(concept_id):
     # Limit the size of the payload, based on the app configuration.
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
-        return make_response(err, 400)
+        return make_response(err, 413)
 
     return jsonify(result)
 
@@ -234,7 +241,7 @@ def concepts_shortestpath_get(origin_concept_id, terminus_concept_id):
     # Limit the size of the payload, based on the app configuration.
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
-        return make_response(err, 400)
+        return make_response(err, 413)
 
     return jsonify(result)
 
@@ -323,7 +330,7 @@ def concepts_trees_get(concept_id):
     # Limit the size of the payload, based on the app configuration.
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
-        return make_response(err, 400)
+        return make_response(err, 413)
 
     return jsonify(result)
 
@@ -388,7 +395,7 @@ def concepts_subgraph_get():
     # Limit the size of the payload, based on the app configuration.
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
-        return make_response(err, 400)
+        return make_response(err, 413)
 
     return jsonify(result)
 
@@ -420,6 +427,12 @@ def concepts_concept_identifier_nodes_get(search):
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
         return make_response(err, 400)
+
+    # Feb 2025
+    # Limit the size of the payload, based on the app configuration.
+    err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
+    if err != "ok":
+        return make_response(err, 413)
 
     dict_result = {'nodeobjects': result}
     return jsonify(dict_result)
@@ -510,6 +523,6 @@ def concepts_paths_subraphs_sequential_get(concept_id=None):
     # Limit the size of the payload, based on the app configuration.
     err = check_payload_size(payload=result, max_payload_size=neo4j_instance.payloadlimit)
     if err != "ok":
-        return make_response(err, 400)
+        return make_response(err, 413)
 
     return jsonify(result)

--- a/src/ubkg_api/utils/http_error_string.py
+++ b/src/ubkg_api/utils/http_error_string.py
@@ -89,8 +89,8 @@ def get_404_error_string(prompt_string=None, custom_request_path=None, timeout=N
         if timeout > 1:
             errtimeout = errtimeout + "s"
 
-        err = err + f". Note that this endpoint is limited to an execution time of {errtimeout}" \
-                    f" to prevent timeout errors."
+        err = err + f". This endpoint is limited to an execution time of {errtimeout}" \
+                    f" to prevent gateway timeout errors."
 
     return wrap_message(key="message", msg=err)
 
@@ -259,8 +259,8 @@ def check_payload_size(payload: str, max_payload_size: int) -> str:
     payload_size = len(str(payload))
     if payload_size > max_payload_size:
         err = f"The size of the response to the endpoint with the specified parameters " \
-               f"({int(payload_size)/1024} MB) exceeds the payload limit" \
-               f" of {int(max_payload_size)/1024} MB."
+               f"({int(payload_size/1024**2)} MB) exceeds the payload limit" \
+               f" of {int(max_payload_size/1024**2)} MB."
         return wrap_message(key="message", msg=err)
 
     return "ok"

--- a/ubkg-api-spec.yaml
+++ b/ubkg-api-spec.yaml
@@ -157,7 +157,7 @@ paths:
           description: The concept identifier (also known as Concept Unique Identifier, or CUI)
           schema:
             type: string
-            example: C0006142
+            example: C4722518
       responses:
         '200':
           description: An array of information on Concepts that have relationships with the specified Concept


### PR DESCRIPTION
All endpoints now check for:
1. query times that exceed a configurable timeout (app.cfg) that is less than the AWS gateway timeout (29 s)
2. response payloads with sizes that exceed a configurable limit that is less than the AWS gateway limit (10 MB).

If one of the checks fails, an error with both HTTP error code and custom error message is returned. 

The timeout message continues to use 404, as before. The error message explains that no records were returned possibly because of timeout--i.e., the endpoint does not raise a 504 error.

The payload message uses a 413 error. This is technically a "response payload too large" error; however, there is no equivalent 5xx error, and it appears that 413 is used generally. 