### PR TITLE
Update python-app.yml to use relative path in install of requirements…

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,5 +22,5 @@ jobs:
       run: python -m pip install --upgrade pip
       working-directory: src/ubkg_api
     - name: Install Dependencies
-      run: pip install -r requirements.txt
+      run: pip install -r src/ubkg_api/requirements.txt
       working-directory: src/ubkg_api


### PR DESCRIPTION
There may be confusion between setting the working directory and including the relative path in the actual install command.